### PR TITLE
Trigger builds on new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,15 +106,21 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - build_site:
           requires:
             - build_data
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - build_site
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/


### PR DESCRIPTION
Let's listen for new tags, so that new releases can be created with a tag, instead of with a tag and extra commit.