### PR TITLE
Bump version number for 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Numbers in parenthesis below refer to Github issues or pull-requests.
 
-## 0.3.1
+## 0.3.2
 
 ### Functionality
 


### PR DESCRIPTION
Bumping the version number of the last release because I had to fix a bug with tag pushes.