### PR TITLE
Revert some goal short titles

### DIFF
--- a/translations/en/global_goals.yml
+++ b/translations/en/global_goals.yml
@@ -5,7 +5,7 @@
   short: Reduced inequalities
   title: Reduce inequality within and among countries
 '11':
-  short: Sustainable cities and communities
+  short: Sustainable cities & communities
   title: Make cities and human settlements inclusive, safe, resilient and sustainable
 '12':
   short: Responsible consumption and production
@@ -23,7 +23,7 @@
     manage forests, combat desertification, and halt and reverse land degradation
     and halt biodiversity loss
 '16':
-  short: Peace, justice and strong institutions
+  short: Peace and justice - strong institutions
   title: Promote peaceful and inclusive societies for sustainable development, provide
     access to justice for all and build effective, accountable and inclusive institutions
     at all levels


### PR DESCRIPTION
It turns out that in one platform (Open SDG) the goal short titles directly affect the URL paths of certain pages. Let's revert this temporarily while we work out a longer-term solution.

More discussion [here](https://github.com/open-sdg/open-sdg/issues/84)