### PR TITLE
Translations of "Status by goal"

### DIFF
--- a/contexts/status.yml
+++ b/contexts/status.yml
@@ -1,0 +1,1 @@
+status_by_goal: Describing a section where the status is reported for each goal.

--- a/translations/am/status.yml
+++ b/translations/am/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Ընդհանուր հաշվետվության կարգ
 reported_online: 'Առցանց հաշվետվություն '
 reporting_status: 'Հաշվետվության կարգավիճակը '
 statistics_in_progress: Վիճակագրությունը ընթացքում է
+status_by_goal: Գոլի կարգավիճակ

--- a/translations/ar/status.yml
+++ b/translations/ar/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: وضع الاعلان العام
 reported_online: اعلن على الانترنت
 reporting_status: وضع الاعلان
 statistics_in_progress: الاحصائيات دائرة
+status_by_goal: الحالة حسب الهدف

--- a/translations/de/status.yml
+++ b/translations/de/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Übersicht zum Berichtsstatus
 reported_online: Daten verfügbar
 reporting_status: Berichtsstatus
 statistics_in_progress: in Bearbeitung
+status_by_goal: Status nach Ziel

--- a/translations/en/data.yml
+++ b/translations/en/data.yml
@@ -1,0 +1,13 @@
+sex: Sex
+female: Female
+male: Male
+age: Age
+urbanisation: Degree of urbanisation
+rural: Rural
+urban: Urban
+income: Income or wealth quantile
+education: Education level
+occupation: Occupation
+disability: Disability status
+unit: Unit of measure
+percent: Percent

--- a/translations/en/status.yml
+++ b/translations/en/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Overall Reporting Status
 reported_online: Reported online
 statistics_in_progress: Statistics in progress
 exploring_data_sources: Exploring data sources
+status_by_goal: Status by goal

--- a/translations/es/status.yml
+++ b/translations/es/status.yml
@@ -3,4 +3,4 @@ overall_reporting_status: Estado general de informes
 reported_online: Reportado en línea
 reporting_status: Estado de informes
 statistics_in_progress: Estadísticas en progreso
-status_by_goal: Estado por objetivo
+status_by_goal: Estados por objetivos

--- a/translations/es/status.yml
+++ b/translations/es/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Estado general de informes
 reported_online: Reportado en línea
 reporting_status: Estado de informes
 statistics_in_progress: Estadísticas en progreso
+status_by_goal: Estado por objetivo

--- a/translations/fr/status.yml
+++ b/translations/fr/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Statut général de rapport
 reported_online: Signalé en ligne
 reporting_status: Statut de rapport
 statistics_in_progress: Statistiques en cours
+status_by_goal: Statut par but

--- a/translations/ru/status.yml
+++ b/translations/ru/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: Общее состояние отчётности
 reported_online: Сообщалось в интернете
 reporting_status: 'Состояние отчётности '
 statistics_in_progress: Статистика в процессе выполнения
+status_by_goal: Статус по цели

--- a/translations/zh-Hans/status.yml
+++ b/translations/zh-Hans/status.yml
@@ -3,3 +3,4 @@ overall_reporting_status: 整体上报状况
 reported_online: 已在线上上报
 reporting_status: 上报状况
 statistics_in_progress: 统计在进行中
+status_by_goal: 目标状态

--- a/translations/zh-Hans/status.yml
+++ b/translations/zh-Hans/status.yml
@@ -3,4 +3,4 @@ overall_reporting_status: 整体上报状况
 reported_online: 已在线上上报
 reporting_status: 上报状况
 statistics_in_progress: 统计在进行中
-status_by_goal: 目标状态
+status_by_goal: 目标状况


### PR DESCRIPTION
Here is a draft of translations of "Status by goal". These were done with Google Translate, so careful review is needed.

Confirmed so far:
- [x] Arabic
- [ ] Armenian
- [x] Chinese
- [ ] French
- [x] German
- [ ] Russian
- [x] Spanish

Fixes #68 