### PR TITLE
Backfill 'am' translations with Armenian in legacy json output

### DIFF
--- a/scripts/build_translations.py
+++ b/scripts/build_translations.py
@@ -26,6 +26,14 @@ def build_translations(output_file):
                 with open(os.path.join(root, file), 'r') as stream:
                     try:
                         yamldata = (yaml.load(stream, Loader=yaml.FullLoader))
+                        # Backwards compatibility for Armenian, whose code changed
+                        # from 'am' to 'hy'.
+                        if no_extension == 'languages' and 'hy' in yamldata:
+                            yamldata['am'] = yamldata['hy']
+                        if key == 'hy':
+                            if 'am' not in data:
+                                data['am'] = {}
+                            data['am'][no_extension] = yamldata
                         data[key][no_extension] = yamldata
                     except Exception as exc:
                         print (exc)


### PR DESCRIPTION
This small change is to allow Armenia to use the latest translations without needing to upgrade their version of Open SDG. It does not affect current translation activities.